### PR TITLE
database: 계정상태 Enum -> varchar로 변경, 계정 비활성화 관련 컬럼추가

### DIFF
--- a/src/main/resources/db/migration/V20250616224741__update_users_table.sql
+++ b/src/main/resources/db/migration/V20250616224741__update_users_table.sql
@@ -1,0 +1,5 @@
+
+ALTER TABLE users
+    MODIFY COLUMN status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE' COMMENT '계정 상태',
+    ADD COLUMN inactivated_at DATETIME COMMENT '계정 비활성화 일시',
+    ADD COLUMN inactivated_type VARCHAR(255) COMMENT '계정 비활성화 타입 (탈퇴, 장기미접속, 불특정IP접속)';


### PR DESCRIPTION
## 📋 상세 설명
- users의 status 컬럼의 타입을 ENUM -> VARCHAR로 변경
- 계정 비활성화 관련 컬럼 추가(inactivated_at, inativated_type)

## 📊 체크리스트

- [ ] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [ ] 코드가 테스트 되었나요
- [ ] 문서는 업데이트 되었나요
- [ ] 불필요한 코드를 제거했나요
- [ ] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #1 
