### PR TITLE
fix: cookie util maxAge를 밀리초에서 초로 변경

### DIFF
--- a/src/main/java/until/the/eternity/das/common/util/CookieUtil.java
+++ b/src/main/java/until/the/eternity/das/common/util/CookieUtil.java
@@ -25,7 +25,7 @@ public class CookieUtil {
       .sameSite("None")
       .path("/")
       .domain(".memonogi.com")
-      .maxAge(jwtConstant.getAccessTokenValidity())
+      .maxAge(jwtConstant.getAccessTokenValidity() / 1000)
       .build();
 
     response.addHeader("Set-Cookie", cookie.toString());
@@ -44,7 +44,7 @@ public class CookieUtil {
       .sameSite("None")
       .path("/")
       .domain(".memonogi.com")
-      .maxAge(jwtConstant.getRefreshTokenValidity())
+      .maxAge(jwtConstant.getRefreshTokenValidity() / 1000)
       .build();
 
     response.addHeader("Set-Cookie", cookie.toString());


### PR DESCRIPTION
## 📋 상세 설명

- cookie util maxAge가 밀리초로 되어 있어 jwt가 만료되지 않은 버그 발생
 - 이를 해결하기 위해 cookie util maxAge를 밀리초에서 초로 변경

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [ ] 문서는 업데이트 되었나요 `업데이트 불필요`
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요 `이슈 미등록`