### PR TITLE
feat: 인증 사용자 닉네임 변경 제한 및 인증 요약 조회 Public API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ application.yml
 
 ### Docker-Compose ###
 .env
+.env.local
+.env.dev
+.env.prod

--- a/src/main/java/until/the/eternity/das/common/config/SecurityConfig.java
+++ b/src/main/java/until/the/eternity/das/common/config/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
       .hasRole("SUPER_ADMIN")
       .requestMatchers("/api/auth/**")
       .permitAll()
+      .requestMatchers("/api/user/verification/public/**")
+      .permitAll()
       .requestMatchers("/api/admin/")
       .hasAnyRole("ADMIN", "SUPER_ADMIN")
 

--- a/src/main/java/until/the/eternity/das/common/exception/GlobalExceptionCode.java
+++ b/src/main/java/until/the/eternity/das/common/exception/GlobalExceptionCode.java
@@ -39,6 +39,7 @@ public enum GlobalExceptionCode implements ExceptionCode {
 
   // User
   USER_INFO_UPDATE_FAILED(INTERNAL_SERVER_ERROR, "사용자 정보 수정에 실패했습니다. 잠시 후 다시 시도해주세요."),
+  USER_VERIFICATION_REQUIRED_FOR_IDENTITY_UPDATE(HttpStatus.BAD_REQUEST, "인증된 계정은 닉네임 또는 서버명을 변경하기 전에 재인증이 필요합니다."),
   USER_VERIFICATION_GENERATE_FAILED(INTERNAL_SERVER_ERROR, "인증 코드 생성에 실패했습니다. 잠시 후 다시 시도해주세요."),
   USER_VERIFICATION_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "발급된 인증 토큰이 존재하지 않습니다."),
   USER_VERIFICATION_TOKEN_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 유효한 인증 토큰이 존재합니다. 재발급을 이용해주세요."),

--- a/src/main/java/until/the/eternity/das/common/exception/GlobalExceptionCode.java
+++ b/src/main/java/until/the/eternity/das/common/exception/GlobalExceptionCode.java
@@ -44,6 +44,7 @@ public enum GlobalExceptionCode implements ExceptionCode {
   USER_VERIFICATION_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "발급된 인증 토큰이 존재하지 않습니다."),
   USER_VERIFICATION_TOKEN_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 유효한 인증 토큰이 존재합니다. 재발급을 이용해주세요."),
   USER_VERIFICATION_COOLDOWN_ACTIVE(HttpStatus.BAD_REQUEST, "최근 7일 이내 인증 성공 이력이 있어 토큰 발급이 불가능합니다."),
+  USER_VERIFICATION_HISTORY_LIMIT_INVALID(HttpStatus.BAD_REQUEST, "인증 내역 조회 limit는 1 이상 100 이하의 값만 허용됩니다."),
   USER_VERIFICATION_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않거나 만료된 인증 코드입니다."),
 
   // OAUTH

--- a/src/main/java/until/the/eternity/das/user/application/UserService.java
+++ b/src/main/java/until/the/eternity/das/user/application/UserService.java
@@ -1,6 +1,7 @@
 package until.the.eternity.das.user.application;
 
 import jakarta.transaction.Transactional;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import until.the.eternity.das.common.aop.ActiveUserRequired;
@@ -28,6 +29,10 @@ public class UserService {
   public Boolean updateUserInfo(UserInfoUpdateRequest request, Long userId) {
     User user = userRepository.findById(userId)
       .orElseThrow(() -> new CustomException(GlobalExceptionCode.USER_NOT_EXISTS));
+
+    boolean wantsNicknameChange =
+      request.nickname() != null && !Objects.equals(request.nickname(), user.getNickname());
+    ensureIdentityUpdateAllowed(user, wantsNicknameChange, false);
 
     String profileImageUrl = null;
 
@@ -75,6 +80,12 @@ public class UserService {
   @Transactional
   public Boolean updateUserPassword() {
     return false;
+  }
+
+  private void ensureIdentityUpdateAllowed(User user, boolean wantsNicknameChange, boolean wantsServerNameChange) {
+    if (user.isVerified() && (wantsNicknameChange || wantsServerNameChange)) {
+      throw new CustomException(GlobalExceptionCode.USER_VERIFICATION_REQUIRED_FOR_IDENTITY_UPDATE);
+    }
   }
 
 }

--- a/src/main/java/until/the/eternity/das/user/application/UserService.java
+++ b/src/main/java/until/the/eternity/das/user/application/UserService.java
@@ -21,7 +21,7 @@ import until.the.eternity.das.user.entity.enums.Status;
 @RequiredArgsConstructor
 public class UserService {
 
-  private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[\\uAC00-\\uD7A3a-zA-Z0-9]{2,20}$");
+  private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]{2,20}$");
 
   private final UserRepository userRepository;
   private final S3Service s3Service;

--- a/src/main/java/until/the/eternity/das/user/application/UserService.java
+++ b/src/main/java/until/the/eternity/das/user/application/UserService.java
@@ -2,6 +2,7 @@ package until.the.eternity.das.user.application;
 
 import jakarta.transaction.Transactional;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import until.the.eternity.das.common.aop.ActiveUserRequired;
@@ -20,6 +21,8 @@ import until.the.eternity.das.user.entity.enums.Status;
 @RequiredArgsConstructor
 public class UserService {
 
+  private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[\\uAC00-\\uD7A3a-zA-Z0-9]{2,20}$");
+
   private final UserRepository userRepository;
   private final S3Service s3Service;
   private final KafkaProducerService kafkaProducerService;
@@ -30,11 +33,16 @@ public class UserService {
     User user = userRepository.findById(userId)
       .orElseThrow(() -> new CustomException(GlobalExceptionCode.USER_NOT_EXISTS));
 
-    boolean wantsNicknameChange =
-      request.nickname() != null && !Objects.equals(request.nickname(), user.getNickname());
-    ensureIdentityUpdateAllowed(user, wantsNicknameChange, false);
+    String nextNickname = resolveNextNickname(request.nickname(), user.getNickname());
 
-    String profileImageUrl = null;
+    boolean wantsNicknameChange = !Objects.equals(nextNickname, user.getNickname());
+    ensureIdentityUpdateAllowed(user, wantsNicknameChange, false);
+    if (wantsNicknameChange) {
+      validateNickname(nextNickname);
+      ensureNicknameAvailable(nextNickname, userId);
+    }
+
+    String profileImageUrl = user.getProfileImageUrl();
 
     if (request.file() != null) {
       if (user.getProfileImageUrl() != null) {
@@ -46,7 +54,7 @@ public class UserService {
     }
 
     try {
-      user.updateUserInfo(request.nickname(), profileImageUrl);
+      user.updateUserInfo(nextNickname, profileImageUrl);
 
       UserInfoUpdateEvent kafKaEvent = UserInfoUpdateEvent.of(user);
 
@@ -85,6 +93,25 @@ public class UserService {
   private void ensureIdentityUpdateAllowed(User user, boolean wantsNicknameChange, boolean wantsServerNameChange) {
     if (user.isVerified() && (wantsNicknameChange || wantsServerNameChange)) {
       throw new CustomException(GlobalExceptionCode.USER_VERIFICATION_REQUIRED_FOR_IDENTITY_UPDATE);
+    }
+  }
+
+  private String resolveNextNickname(String requestedNickname, String currentNickname) {
+    if (requestedNickname == null || requestedNickname.isBlank()) {
+      return currentNickname;
+    }
+    return requestedNickname.trim();
+  }
+
+  private void validateNickname(String nickname) {
+    if (!NICKNAME_PATTERN.matcher(nickname).matches()) {
+      throw new CustomException(GlobalExceptionCode.INVALID_NICKNAME_FORMAT);
+    }
+  }
+
+  private void ensureNicknameAvailable(String nickname, Long userId) {
+    if (userRepository.existsByNicknameAndIdNot(nickname, userId)) {
+      throw new CustomException(GlobalExceptionCode.NICKNAME_ALREADY_EXISTS);
     }
   }
 

--- a/src/main/java/until/the/eternity/das/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/until/the/eternity/das/user/dto/response/UserInfoResponse.java
@@ -10,6 +10,7 @@ public record UserInfoResponse(
   String nickname,
   String profileImageUrl,
   String role,
+  boolean verified,
   LocalDateTime createdAt,
   LocalDateTime lastLoginAt
 ) {
@@ -22,6 +23,7 @@ public record UserInfoResponse(
       user.getRole()
         .getName()
         .name(),
+      user.isVerified(),
       user.getCreatedAt(),
       user.getLastLoginAt()
     );

--- a/src/main/java/until/the/eternity/das/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/until/the/eternity/das/user/dto/response/UserInfoResponse.java
@@ -9,6 +9,7 @@ public record UserInfoResponse(
   String email,
   String nickname,
   String profileImageUrl,
+  String serverName,
   String role,
   boolean verified,
   LocalDateTime createdAt,
@@ -20,6 +21,7 @@ public record UserInfoResponse(
       user.getEmail(),
       user.getNickname(),
       user.getProfileImageUrl(),
+      user.getServerName(),
       user.getRole()
         .getName()
         .name(),

--- a/src/main/java/until/the/eternity/das/verification/application/UserVerificationService.java
+++ b/src/main/java/until/the/eternity/das/verification/application/UserVerificationService.java
@@ -24,6 +24,7 @@ import until.the.eternity.das.user.entity.UserRepository;
 import until.the.eternity.das.verification.dto.response.UserVerificationHistoryResponse;
 import until.the.eternity.das.verification.dto.response.UserVerificationHistoryListResponse;
 import until.the.eternity.das.verification.dto.response.UserVerificationInfoResponse;
+import until.the.eternity.das.verification.dto.response.UserVerificationPublicSummaryResponse;
 import until.the.eternity.das.verification.dto.response.UserVerificationTokenIssueResponse;
 import until.the.eternity.das.verification.dto.response.UserVerificationTokenResponse;
 import until.the.eternity.das.verification.entity.UserVerification;
@@ -131,6 +132,26 @@ public class UserVerificationService {
   public UserVerificationInfoResponse getUserVerificationInfo(Long userId) {
     ensureUserExists(userId);
     return UserVerificationInfoResponse.of(userId, userVerificationRepository.findByUserId(userId).orElse(null));
+  }
+
+  @Transactional(readOnly = true)
+  public UserVerificationPublicSummaryResponse getUserVerificationPublicSummary(Long userId, Integer limit) {
+    ensureUserExists(userId);
+
+    int normalizedLimit = normalizeLimit(limit);
+
+    List<UserVerificationHistoryResponse> histories = userVerificationHistoryRepository
+      .findTop100ByUserIdOrderByVerifiedAtDesc(userId)
+      .stream()
+      .limit(normalizedLimit)
+      .map(UserVerificationHistoryResponse::of)
+      .toList();
+
+    return UserVerificationPublicSummaryResponse.of(
+      userId,
+      userVerificationRepository.findByUserId(userId).orElse(null),
+      histories
+    );
   }
 
   @Transactional

--- a/src/main/java/until/the/eternity/das/verification/application/UserVerificationService.java
+++ b/src/main/java/until/the/eternity/das/verification/application/UserVerificationService.java
@@ -341,10 +341,10 @@ public class UserVerificationService {
     if (limit == null) {
       return 20;
     }
-    if (limit < 1) {
-      return 1;
+    if (limit < 1 || limit > 100) {
+      throw new CustomException(GlobalExceptionCode.USER_VERIFICATION_HISTORY_LIMIT_INVALID);
     }
-    return Math.min(limit, 100);
+    return limit;
   }
 
   private String normalizeSort(String sort) {

--- a/src/main/java/until/the/eternity/das/verification/dto/response/UserVerificationPublicSummaryResponse.java
+++ b/src/main/java/until/the/eternity/das/verification/dto/response/UserVerificationPublicSummaryResponse.java
@@ -1,0 +1,44 @@
+package until.the.eternity.das.verification.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import until.the.eternity.das.verification.entity.UserVerification;
+
+public record UserVerificationPublicSummaryResponse(
+  Long userId,
+  boolean verified,
+  String serverName,
+  String characterName,
+  LocalDateTime lastVerifiedAt,
+  int verificationCount,
+  List<UserVerificationHistoryResponse> histories
+) {
+
+  public static UserVerificationPublicSummaryResponse of(
+    Long userId,
+    UserVerification verification,
+    List<UserVerificationHistoryResponse> histories
+  ) {
+    if (verification == null) {
+      return new UserVerificationPublicSummaryResponse(
+        userId,
+        false,
+        null,
+        null,
+        null,
+        0,
+        histories
+      );
+    }
+
+    return new UserVerificationPublicSummaryResponse(
+      userId,
+      verification.isVerified(),
+      verification.getServerName(),
+      verification.getCharacterName(),
+      verification.getLastVerifiedAt(),
+      verification.getVerificationCount(),
+      histories
+    );
+  }
+}

--- a/src/main/java/until/the/eternity/das/verification/presentation/UserVerificationController.java
+++ b/src/main/java/until/the/eternity/das/verification/presentation/UserVerificationController.java
@@ -1,5 +1,6 @@
 package until.the.eternity.das.verification.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,6 +26,10 @@ public class UserVerificationController {
   private final UserVerificationService userVerificationService;
 
   @PostMapping("/token")
+  @Operation(
+    summary = "사용자 인증 토큰 발급",
+    description = "사용자가 최초 인증을 진행할 수 있도록 신규 인증 토큰을 발급합니다."
+  )
   public ResponseEntity<CommonResponse<UserVerificationTokenIssueResponse>> issueToken(
     @AuthenticationPrincipal Long id
   ) {
@@ -32,6 +37,10 @@ public class UserVerificationController {
   }
 
   @GetMapping("/token")
+  @Operation(
+    summary = "내 인증 토큰 조회",
+    description = "가장 최근에 발급된 인증 토큰 정보를 조회합니다."
+  )
   public ResponseEntity<CommonResponse<UserVerificationTokenResponse>> getMyToken(
     @AuthenticationPrincipal Long id
   ) {
@@ -39,6 +48,10 @@ public class UserVerificationController {
   }
 
   @PostMapping("/token/reissue")
+  @Operation(
+    summary = "인증 토큰 재발급",
+    description = "기존 토큰을 폐기하고 새로운 인증 토큰을 재발급합니다."
+  )
   public ResponseEntity<CommonResponse<UserVerificationTokenIssueResponse>> reissueToken(
     @AuthenticationPrincipal Long id
   ) {
@@ -46,6 +59,10 @@ public class UserVerificationController {
   }
 
   @GetMapping("/info")
+  @Operation(
+    summary = "내 인증 상태 조회",
+    description = "현재 로그인한 사용자의 인증 여부, 서버명, 캐릭터명 등을 조회합니다."
+  )
   public ResponseEntity<CommonResponse<UserVerificationInfoResponse>> getMyVerificationInfo(
     @AuthenticationPrincipal Long id
   ) {
@@ -53,6 +70,10 @@ public class UserVerificationController {
   }
 
   @GetMapping("/history")
+  @Operation(
+    summary = "내 인증 이력 조회",
+    description = "정렬 기준과 조회 개수를 지정하여 개인 인증 히스토리를 조회합니다."
+  )
   public ResponseEntity<CommonResponse<UserVerificationHistoryListResponse>> getMyVerificationHistory(
     @AuthenticationPrincipal Long id,
     @RequestParam(defaultValue = "latest") String sort,
@@ -62,6 +83,10 @@ public class UserVerificationController {
   }
 
   @GetMapping("/users/{userId}/info")
+  @Operation(
+    summary = "사용자 인증 상태 조회",
+    description = "특정 사용자 ID에 대한 최신 인증 상태 정보를 조회합니다."
+  )
   public ResponseEntity<CommonResponse<UserVerificationInfoResponse>> getUserVerificationInfo(
     @PathVariable Long userId
   ) {
@@ -69,6 +94,10 @@ public class UserVerificationController {
   }
 
   @GetMapping("/public/users/{userId}/summary")
+  @Operation(
+    summary = "공개 인증 요약 조회",
+    description = "특정 사용자의 현재 인증 상태와 최근 인증 이력을 공개 용도로 조회합니다."
+  )
   public ResponseEntity<CommonResponse<UserVerificationPublicSummaryResponse>> getUserVerificationPublicSummary(
     @PathVariable Long userId,
     @RequestParam(defaultValue = "20") Integer limit

--- a/src/main/java/until/the/eternity/das/verification/presentation/UserVerificationController.java
+++ b/src/main/java/until/the/eternity/das/verification/presentation/UserVerificationController.java
@@ -13,6 +13,7 @@ import until.the.eternity.das.common.response.CommonResponse;
 import until.the.eternity.das.verification.application.UserVerificationService;
 import until.the.eternity.das.verification.dto.response.UserVerificationHistoryListResponse;
 import until.the.eternity.das.verification.dto.response.UserVerificationInfoResponse;
+import until.the.eternity.das.verification.dto.response.UserVerificationPublicSummaryResponse;
 import until.the.eternity.das.verification.dto.response.UserVerificationTokenIssueResponse;
 import until.the.eternity.das.verification.dto.response.UserVerificationTokenResponse;
 
@@ -65,5 +66,15 @@ public class UserVerificationController {
     @PathVariable Long userId
   ) {
     return ResponseEntity.ok(CommonResponse.success(userVerificationService.getUserVerificationInfo(userId)));
+  }
+
+  @GetMapping("/public/users/{userId}/summary")
+  public ResponseEntity<CommonResponse<UserVerificationPublicSummaryResponse>> getUserVerificationPublicSummary(
+    @PathVariable Long userId,
+    @RequestParam(defaultValue = "20") Integer limit
+  ) {
+    return ResponseEntity.ok(
+      CommonResponse.success(userVerificationService.getUserVerificationPublicSummary(userId, limit))
+    );
   }
 }


### PR DESCRIPTION
## 📋 상세 설명

- 사용자 정보 수정 시 인증 사용자 닉네임 변경 차단 검증 추가
- 사용자 인증 상태/이력 조회 Public API 신규 추가
  - /api/user/verification/public/users/{userId}/summary
- Verification 컨트롤러 전 엔드포인트에 Swagger @Operation 추가
- UserInfoResponse에 serverName, verified 필드 추가
- 새 이미지 미업로드 시 기존 프로필 이미지 유지하도록 수정

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요
